### PR TITLE
Dependency Updates (Compose Beta 8)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.0-alpha15")
+        classpath("com.android.tools.build:gradle:7.0.0-beta02")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:_")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ include(":datastore-manager")
 include(":app")
 
 plugins {
-    id("de.fayard.refreshVersions") version "0.10.0"
+    id("de.fayard.refreshVersions") version "0.10.1"
 }
 
 buildscript {

--- a/versions.properties
+++ b/versions.properties
@@ -7,22 +7,18 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
-version.androidx.activity=1.3.0-alpha07
+version.androidx.activity=1.3.0-beta01
 
-version.androidx.appcompat=1.2.0
-##             # available=1.3.0-alpha01
-##             # available=1.3.0-alpha02
-##             # available=1.3.0-beta01
-##             # available=1.3.0-rc01
+version.androidx.appcompat=1.3.0
+##             # available=1.4.0-alpha01
+##             # available=1.4.0-alpha02
 
-version.androidx.compose.material=1.0.0-beta06
+version.androidx.compose.material=1.0.0-beta08
 
 version.androidx.datastore=1.0.0-beta01
 
-version.google.accompanist=0.9.1
+version.google.accompanist=0.11.1
 
-version.kotlin=1.4.32
-## # available=1.5.0-M1
-## # available=1.5.0-M2
-## # available=1.5.0-RC
-## # available=1.5.0
+version.kotlin=1.5.10
+## # available=1.5.20-M1
+## # available=1.5.20-RC


### PR DESCRIPTION
This PR updates some dependencies, most notably Jetpack Compose to 1.0.0-Beta08

Other updates:
- RefreshVersions 0.10.0 -> 0.10.1
- AGP 7.0.0-alpha15 -> 7.0.0-beta02
- AndroidX Activity 1.3.0-alpha07 -> 1.3.0
- Accompanist 0.9.1 -> 0.11.1
- Kotlin 1.4.32 -> 1.5.10